### PR TITLE
Rename "session media elements" to "participating media elements"

### DIFF
--- a/mediasession.bs
+++ b/mediasession.bs
@@ -227,18 +227,18 @@ underlying platform and other <a lt="media element">media elements</a> belonging
 to other <a lt="media session">media sessions</a> within the user agent.
 
 A <a>media element</a> can have a <dfn>current media session</dfn>, which is a
-<a>media session</a> object. When a <a>media element</a> is created it does not
-have a <a>current media session</a>.
+<a>media session</a>. When a <a>media element</a> is created it does not have a
+<a>current media session</a>.
 
-A <a>media element</a> obtains a <a>current media session</a> object only when
-it first reaches a <a>potentially playing</a> state per the <a>media session
-invocation algorithm</a> below. A <a>media element</a>'s <a>current media
-session</a> is removed when it subsequently reaches a non-<a>potentially
-playing</a> state per the <a>media session termination algorithm</a> below.
+A <a>media element</a> obtains a <a>current media session</a> only when it first
+reaches a <a>potentially playing</a> state per the <a>media session invocation
+algorithm</a> below. A <a>media element</a>'s <a>current media session</a> is
+removed when it subsequently reaches a non-<a>potentially playing</a> state per
+the <a>media session termination algorithm</a> below.
 
-The <dfn>session media elements</dfn> of a <a>media session</a> object are the
+The <dfn>session media elements</dfn> of a <a>media session</a> are the
 <a>media elements</a> whose <a>current media session</a> is that
-<a>media session</a> object.
+<a>media session</a>.
 
 <h2 id="setting-media-category">Assigning a Media Category to Media
 Elements</h2>
@@ -334,7 +334,7 @@ consists of the following steps, passing in the <a>media element</a> as
   </li>
   <li>
     Let <var>media session</var> be the current <a>top-level browsing
-    context</a>'s <a>media session</a> object that matches <var>media category
+    context</a>'s <a>media session</a> that matches <var>media category
     state</var>. If no <var>media session</var> is available in the <a>top-level
     browsing context</a> that matches <var>media category state</var> then, let
     <var>media session</var> be a new <a>media session</a> with a <a>media

--- a/mediasession.bs
+++ b/mediasession.bs
@@ -236,7 +236,7 @@ algorithm</a> below. A <a>media element</a>'s <a>current media session</a> is
 removed when it subsequently reaches a non-<a>potentially playing</a> state per
 the <a>media session termination algorithm</a> below.
 
-The <dfn>session media elements</dfn> of a <a>media session</a> are the
+The <dfn>participating media elements</dfn> of a <a>media session</a> are the
 <a>media elements</a> whose <a>current media session</a> is that
 <a>media session</a>.
 
@@ -344,10 +344,6 @@ consists of the following steps, passing in the <a>media element</a> as
     session</var>, also request the most appropriate platform-level media focus
     for the <var>media session</var> based on the current <var>media category
     state</var>.
-  </li>
-  <li>
-    Add a reference to the <var>current media element</var> to <var>media
-    session</var>'s <a>session media elements</a>.
   </li>
   <li>
     Set <var>current media element</var>'s <a>current media session</a> to
@@ -463,10 +459,6 @@ steps, passing in the <a>media element</a> as <var>current media element</var>.
   </li>
   <li>
     Return and run the remaining steps asynchronously.
-  </li>
-  <li>
-    Remove the reference for the <var>current media element</var> from
-    <var>media session</var>'s <a>session media elements</a>.
   </li>
   <li>
     Remove <a>current media session</a> from <var>current media element</var>.

--- a/mediasession.html
+++ b/mediasession.html
@@ -482,20 +482,20 @@ to other <a data-link-type="dfn" href="#media-session">media sessions</a> within
 
 
    <p>A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> can have a <dfn data-dfn-type="dfn" data-noexport="" id="current-media-session">current media session<a class="self-link" href="#current-media-session"></a></dfn>, which is a
-<a data-link-type="dfn" href="#media-session">media session</a> object. When a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> is created it does not
-have a <a data-link-type="dfn" href="#current-media-session">current media session</a>.</p>
+<a data-link-type="dfn" href="#media-session">media session</a>. When a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> is created it does not have a
+<a data-link-type="dfn" href="#current-media-session">current media session</a>.</p>
 
 
-   <p>A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> obtains a <a data-link-type="dfn" href="#current-media-session">current media session</a> object only when
-it first reaches a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#potentially-playing">potentially playing</a> state per the <a data-link-type="dfn" href="#media-session-invocation-algorithm">media session
-invocation algorithm</a> below. A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a>’s <a data-link-type="dfn" href="#current-media-session">current media
-session</a> is removed when it subsequently reaches a non-<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#potentially-playing">potentially
-playing</a> state per the <a data-link-type="dfn" href="#media-session-termination-algorithm">media session termination algorithm</a> below.</p>
+   <p>A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> obtains a <a data-link-type="dfn" href="#current-media-session">current media session</a> only when it first
+reaches a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#potentially-playing">potentially playing</a> state per the <a data-link-type="dfn" href="#media-session-invocation-algorithm">media session invocation
+algorithm</a> below. A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a>’s <a data-link-type="dfn" href="#current-media-session">current media session</a> is
+removed when it subsequently reaches a non-<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#potentially-playing">potentially playing</a> state per
+the <a data-link-type="dfn" href="#media-session-termination-algorithm">media session termination algorithm</a> below.</p>
 
 
-   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="session-media-elements">session media elements<a class="self-link" href="#session-media-elements"></a></dfn> of a <a data-link-type="dfn" href="#media-session">media session</a> object are the
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="session-media-elements">session media elements<a class="self-link" href="#session-media-elements"></a></dfn> of a <a data-link-type="dfn" href="#media-session">media session</a> are the
 <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media elements</a> whose <a data-link-type="dfn" href="#current-media-session">current media session</a> is that
-<a data-link-type="dfn" href="#media-session">media session</a> object.</p>
+<a data-link-type="dfn" href="#media-session">media session</a>.</p>
 
 
    <h2 class="heading settled" data-level="7" id="setting-media-category"><span class="secno">7. </span><span class="content">Assigning a Media Category to Media
@@ -609,7 +609,7 @@ consists of the following steps, passing in the <a data-link-type="dfn" href="ht
   
     <li>
     Let <var>media session</var> be the current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing
-    context</a>’s <a data-link-type="dfn" href="#media-session">media session</a> object that matches <var>media category
+    context</a>’s <a data-link-type="dfn" href="#media-session">media session</a> that matches <var>media category
     state</var>. If no <var>media session</var> is available in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level
     browsing context</a> that matches <var>media category state</var> then, let
     <var>media session</var> be a new <a data-link-type="dfn" href="#media-session">media session</a> with a <a data-link-type="dfn" href="#media-category">media

--- a/mediasession.html
+++ b/mediasession.html
@@ -493,7 +493,7 @@ removed when it subsequently reaches a non-<a data-link-type="dfn" href="https:/
 the <a data-link-type="dfn" href="#media-session-termination-algorithm">media session termination algorithm</a> below.</p>
 
 
-   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="session-media-elements">session media elements<a class="self-link" href="#session-media-elements"></a></dfn> of a <a data-link-type="dfn" href="#media-session">media session</a> are the
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="participating-media-elements">participating media elements<a class="self-link" href="#participating-media-elements"></a></dfn> of a <a data-link-type="dfn" href="#media-session">media session</a> are the
 <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media elements</a> whose <a data-link-type="dfn" href="#current-media-session">current media session</a> is that
 <a data-link-type="dfn" href="#media-session">media session</a>.</p>
 
@@ -621,11 +621,6 @@ consists of the following steps, passing in the <a data-link-type="dfn" href="ht
     for the <var>media session</var> based on the current <var>media category
     state</var>.</p>
      
-  
-  
-    <li>
-    Add a reference to the <var>current media element</var> to <var>media
-    session</var>’s <a data-link-type="dfn" href="#session-media-elements">session media elements</a>.
   
   
     <li>
@@ -772,11 +767,6 @@ steps, passing in the <a data-link-type="dfn" href="https://html.spec.whatwg.org
   
   
     <li>
-    Remove the reference for the <var>current media element</var> from
-    <var>media session</var>’s <a data-link-type="dfn" href="#session-media-elements">session media elements</a>.
-  
-  
-    <li>
     Remove <a data-link-type="dfn" href="#current-media-session">current media session</a> from <var>current media element</var>.
   
   
@@ -817,7 +807,7 @@ steps, passing in the <a data-link-type="dfn" href="https://html.spec.whatwg.org
    <li>media session, <a href="#media-session">6</a>
    <li>media session invocation algorithm, <a href="#media-session-invocation-algorithm">8</a>
    <li>media session termination algorithm, <a href="#media-session-termination-algorithm">10</a>
-   <li>session media elements, <a href="#session-media-elements">6</a>
+   <li>participating media elements, <a href="#participating-media-elements">6</a>
    <li>transient attribute
       value, <a href="#transient-attribute-value">5</a>
    <li>transient media state, <a href="#transient-media-state">5</a>


### PR DESCRIPTION
This is (hopefully) a more memorable name, and is in analogy to the
"slaved media elements" of media controllers.

Just like slaved media elements, the set does not need to be maintained
explicitly, since it's defined by which media elements have a media
session as its current media session, so it's always in sync.

This leaves the concept unused, but it won't be for long.
