### PR TITLE
Use the "extensions to" terminology in place of "additions to"

### DIFF
--- a/mediasession.bs
+++ b/mediasession.bs
@@ -243,7 +243,7 @@ The <dfn>session media elements</dfn> of a <a>media session</a> object are the
 <h2 id="setting-media-category">Assigning a media category to media
 elements</h2>
 
-<h3 id="html-media-element-additions">Additions to {{HTMLMediaElement}}</h3>
+<h3>Extensions to the {{HTMLMediaElement}} interface</h3>
 
 <pre class="idl">
 partial interface HTMLMediaElement {
@@ -280,8 +280,7 @@ The <code>{{HTMLMediaElement/kind}}</code> IDL attribute must
 element>audio</a></code> element content attribute of the same name, <a>limited
 to only known values</a>.
 
-<h3 id="video-element-additions">Additions to the <code><a
-element>video</a></code> element</h3>
+<h3>Extensions to the <code><a element>video</a></code> element</h3>
 
 <dl class="element">
   <dt>
@@ -297,8 +296,7 @@ The <code><a lt="video kind">kind</a></code> content attribute on a
 and must return the video element's <a>media category</a>, if it has one, or the
 empty string otherwise.
 
-<h3 id="audio-element-additions">Additions to the <code><a
-element>audio</a></code> element</h3>
+<h3>Extensions to the <code><a element>audio</a></code> element</h3>
 
 <dl class="element">
   <dt>

--- a/mediasession.html
+++ b/mediasession.html
@@ -212,9 +212,9 @@ mobile devices.</p>
     <li><a href="#setting-media-category"><span class="secno">7</span> <span class="content">Assigning a media category to media
 elements</span></a>
      <ul class="toc">
-      <li><a href="#html-media-element-additions"><span class="secno">7.1</span> <span class="content">Additions to <code class="idl"><span>HTMLMediaElement</span></code></span></a>
-      <li><a href="#video-element-additions"><span class="secno">7.2</span> <span class="content">Additions to the <code><span>video</span></code> element</span></a>
-      <li><a href="#audio-element-additions"><span class="secno">7.3</span> <span class="content">Additions to the <code><span>audio</span></code> element</span></a>
+      <li><a href="#extensions-to-the-htmlmediaelement-interface"><span class="secno">7.1</span> <span class="content">Extensions to the <code class="idl"><span>HTMLMediaElement</span></code> interface</span></a>
+      <li><a href="#extensions-to-the-video-element"><span class="secno">7.2</span> <span class="content">Extensions to the <code><span>video</span></code> element</span></a>
+      <li><a href="#extensions-to-the-audio-element"><span class="secno">7.3</span> <span class="content">Extensions to the <code><span>audio</span></code> element</span></a>
      </ul>
     <li><a href="#invoking-media-session"><span class="secno">8</span> <span class="content">Media session invocation</span></a>
     <li><a href="#interrupting-media-session"><span class="secno">9</span> <span class="content">Media session interruption</span></a>
@@ -502,7 +502,7 @@ playing</a> state per the <a data-link-type="dfn" href="#media-session-terminati
 elements</span><a class="self-link" href="#setting-media-category"></a></h2>
 
 
-   <h3 class="heading settled" data-level="7.1" id="html-media-element-additions"><span class="secno">7.1. </span><span class="content">Additions to <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a></code></span><a class="self-link" href="#html-media-element-additions"></a></h3>
+   <h3 class="heading settled" data-level="7.1" id="extensions-to-the-htmlmediaelement-interface"><span class="secno">7.1. </span><span class="content">Extensions to the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a></code> interface</span><a class="self-link" href="#extensions-to-the-htmlmediaelement-interface"></a></h3>
 
 
    <pre class="idl">partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a> {
@@ -544,7 +544,7 @@ to which the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipag
 to only known values</a>.</p>
 
 
-   <h3 class="heading settled" data-level="7.2" id="video-element-additions"><span class="secno">7.2. </span><span class="content">Additions to the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#video">video</a></code> element</span><a class="self-link" href="#video-element-additions"></a></h3>
+   <h3 class="heading settled" data-level="7.2" id="extensions-to-the-video-element"><span class="secno">7.2. </span><span class="content">Extensions to the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#video">video</a></code> element</span><a class="self-link" href="#extensions-to-the-video-element"></a></h3>
 
 
    <dl class="element">
@@ -565,7 +565,7 @@ and must return the video element’s <a data-link-type="dfn" href="#media-categ
 empty string otherwise.</p>
 
 
-   <h3 class="heading settled" data-level="7.3" id="audio-element-additions"><span class="secno">7.3. </span><span class="content">Additions to the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#audio">audio</a></code> element</span><a class="self-link" href="#audio-element-additions"></a></h3>
+   <h3 class="heading settled" data-level="7.3" id="extensions-to-the-audio-element"><span class="secno">7.3. </span><span class="content">Extensions to the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#audio">audio</a></code> element</span><a class="self-link" href="#extensions-to-the-audio-element"></a></h3>
 
 
    <dl class="element">


### PR DESCRIPTION
This is the terminology used in many specs:
http://dev.w3.org/csswg/cssom/#extensions-to-the-document-interface
http://dev.w3.org/csswg/cssom-view/#extensions-to-the-htmlimageelement-interface
http://w3c.github.io/selection-api/#extensions-to-document-interface
http://w3c.github.io/webcomponents/spec/shadow/#extensions-to-element-interface
http://w3c.github.io/web-animations/#extensions-to-the-document-interface

Also remove the ID overrides since the default ones are good.