### PR TITLE
Drop the empty string from MediaSessionKind

### DIFF
--- a/mediasession.bs
+++ b/mediasession.bs
@@ -281,8 +281,7 @@ enum MediaSessionKind {
   "content",
   "transient",
   "transientsolo",
-  "ambient",
-  ""
+  "ambient"
 };
 </pre>
 

--- a/mediasession.html
+++ b/mediasession.html
@@ -494,8 +494,7 @@ platform-specific interaction and interoperation between web media.</p>
   "content",
   "transient",
   "transientsolo",
-  "ambient",
-  ""
+  "ambient"
 };
 </pre>
 
@@ -1601,8 +1600,7 @@ enum <a data-global-name="" href="#enumdef-mediasessionkind">MediaSessionKind</a
   "content",
   "transient",
   "transientsolo",
-  "ambient",
-  ""
+  "ambient"
 };
 
 partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a> {


### PR DESCRIPTION
kind="" corresponds to a default media session, which doesn't have
an expose MediaSession object on which to observe the empty string.