### PR TITLE
Remove prose for handling invalid media session kinds internally

### DIFF
--- a/mediasession.bs
+++ b/mediasession.bs
@@ -209,12 +209,7 @@ run these steps:
   <li>
     Set <var>media session</var>'s <a>current media session type</a> to the
     corresponding <a>media session type</a> of <var>media session
-    category</var>. If no corresponding <a>media session type</a> can be found
-    for the provided
-    <var>media session category</var> or <var>media session category</var> is
-    empty, then set <var>media session</var>'s
-    <a>current media session type</a> to &quot;<a lt="content attribute
-    value"><code>content</code></a>&quot.
+    category</var>.
   </li>
   <li>
     Set <var>media session</var>'s <a>current state</a> to <code><a lt="idle

--- a/mediasession.html
+++ b/mediasession.html
@@ -320,11 +320,7 @@ run these steps:</p>
     <li>
     Set <var>media session</var>’s <a data-link-type="dfn" href="#current-media-session-type">current media session type</a> to the
     corresponding <a data-link-type="dfn" href="#media-session-type">media session type</a> of <var>media session
-    category</var>. If no corresponding <a data-link-type="dfn" href="#media-session-type">media session type</a> can be found
-    for the provided
-    <var>media session category</var> or <var>media session category</var> is
-    empty, then set <var>media session</var>’s
-    <a data-link-type="dfn" href="#current-media-session-type">current media session type</a> to "<a data-link-type="dfn" href="#content-attribute-value"><code>content</code></a>".
+    category</var>.
   
   
     <li>


### PR DESCRIPTION
There are no paths into this algorithm with arbitrary strings.

Fixes https://github.com/whatwg/mediasession/issues/72