### PR TITLE
Reject the activate() promise with an InvalidStateError DOMException

### DIFF
--- a/mediasession.bs
+++ b/mediasession.bs
@@ -286,8 +286,8 @@ invoked, must run these steps:
     <a>Activate</a> <var>media session</var>.
   </li>
   <li>
-    Issue: If <a>activate</a> failed, reject <var>promise</var> with a
-    <code>DOMException</code> or a <code>TypeError</code>.
+    If <a>activate</a> failed, reject <var>promise</var> with an
+    {{InvalidStateError}} exception.
   </li>
   <li>
     Otherwise, fulfill <var>promise</var> with undefined.

--- a/mediasession.html
+++ b/mediasession.html
@@ -237,7 +237,7 @@ invoked, must run these steps:</p>
     <li> Let <var>promise</var> be a new promise. 
     <li> Return <var>promise</var>, and run the remaining steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>. 
     <li> <a data-link-type="dfn" href="#activate">Activate</a> <var>media session</var>. 
-    <li> Issue: If <a data-link-type="dfn" href="#activate">activate</a> failed, reject <var>promise</var> with a <code>DOMException</code> or a <code>TypeError</code>. 
+    <li> If <a data-link-type="dfn" href="#activate">activate</a> failed, reject <var>promise</var> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception. 
     <li> Otherwise, fulfill <var>promise</var> with undefined. 
    </ol>
    <p class="note" role="note">Note: <code class="idl"><a data-link-type="idl" href="#dom-mediasession-activate">activate()</a></code> can fail if there is an ongoing high-priority activity,


### PR DESCRIPTION
There's still an open spec issue for this:
https://github.com/whatwg/mediasession/issues/112

In the implementation we use DOMException, so spec that for now:
https://codereview.chromium.org/1370453002/